### PR TITLE
Revert "Bring back `allow_failure` to commits schema."

### DIFF
--- a/tap_gitlab/schemas/commits.json
+++ b/tap_gitlab/schemas/commits.json
@@ -63,9 +63,6 @@
         "committer_email": {
             "type": ["null", "string"]
         },
-        "allow_failure": {
-            "type": ["null", "boolean"]
-        },
         "committed_date": {
             "anyOf": [
                 {


### PR DESCRIPTION
Reverts TasmanAnalytics/tap-gitlab#3